### PR TITLE
Sort memory experiment (candidate for v1.0.6)

### DIFF
--- a/Dockerfile-player
+++ b/Dockerfile-player
@@ -74,4 +74,4 @@ RUN chmod 755 /root/*.sh && \
 
 WORKDIR /root
 
-ENTRYPOINT ["./docker-player-entrypoint.sh"]
+CMD ["./docker-player-entrypoint.sh"]

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -28,7 +28,7 @@ clean_finish: no
 # Blank assumes no registry (i.e. 'docker.io')
 nextflow_container_registry: ''
 nextflow_container_name: informaticsmatters/fragmentor
-nextflow_container_tag: '1.0.4'
+nextflow_container_tag: '1.0.6'
 
 # Memory requested by the 'sort' processes in the nextflow workflow
 # (namely fragmentation and combination). Where it's actually used

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -30,13 +30,13 @@ nextflow_container_registry: ''
 nextflow_container_name: informaticsmatters/fragmentor
 nextflow_container_tag: '1.0.4'
 
-# Memory requested by a number of 'sort' processes
-# in the nextflow workflow (namely fragmentation and combination).
-# If set to '0' sort memory will not be requested.
-#
-# Note:   We currently need to set this to '0'
-#         for AWS Slurm-based parallel clusters
-nextflow_process_sort_memory: 8G
+# Memory requested by the 'sort' processes in the nextflow workflow
+# (namely fragmentation and combination). Where it's actually used
+# it is used to set the process memory request for nextflow
+# and a smaller value (typically 80% of the value you specify here)
+# used for the sort commands in the process.
+# Minimum value is 100.
+nextflow_process_sort_memory_m: 8192
 
 # Cloud provider for the database server.
 # Typically one of 'openstack' or 'aws'

--- a/ansible/roles/combine/tasks/main.yaml
+++ b/ansible/roles/combine/tasks/main.yaml
@@ -57,6 +57,11 @@
     - runpath|string != 'SetMe'
     fail_msg: You must provide a 'deployment', a list of extracts in a parameter file to combine and an output location.
 
+- name: Assert sort memory
+  assert:
+    that:
+    - nextflow_process_sort_memory_m|int >= 100
+
 - name: List input datasets
   debug:
     msg: "{{ item.lib }}"

--- a/ansible/roles/combine/templates/deduplicate.nf.j2
+++ b/ansible/roles/combine/templates/deduplicate.nf.j2
@@ -68,7 +68,7 @@ process eDedup {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-    memory '{{ nextflow_process_sort_memory_m }}M'
+    memory '{{ nextflow_process_sort_memory_m }} MB'
     publishDir '{{ next_path }}/results/', mode: 'symlink'
     scratch false
     errorStrategy = 'retry'

--- a/ansible/roles/combine/templates/deduplicate.nf.j2
+++ b/ansible/roles/combine/templates/deduplicate.nf.j2
@@ -68,9 +68,7 @@ process eDedup {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-{% if nextflow_process_sort_memory %}
-    memory '{{ nextflow_process_sort_memory }}'
-{% endif %}
+    memory '{{ nextflow_process_sort_memory_m }}M'
     publishDir '{{ next_path }}/results/', mode: 'symlink'
     scratch false
     errorStrategy = 'retry'
@@ -84,7 +82,7 @@ process eDedup {
 
     shell:
     '''
-    sort --temporary-directory=. -u !{shard} > !{shard}.d-edges
+    sort -u -S {{ (nextflow_process_sort_memory_m * 0.8)|int }}M -T . !{shard} > !{shard}.d-edges
     rm !{shard}
     '''
 

--- a/ansible/roles/combine/templates/merge.nf.j2
+++ b/ansible/roles/combine/templates/merge.nf.j2
@@ -67,7 +67,7 @@ process nMerge {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-    memory '{{ nextflow_process_sort_memory_m }}M'
+    memory '{{ nextflow_process_sort_memory_m }} MB'
     publishDir '{{ next_path }}/results/', mode: 'symlink'
     scratch false
     errorStrategy = 'retry'

--- a/ansible/roles/combine/templates/merge.nf.j2
+++ b/ansible/roles/combine/templates/merge.nf.j2
@@ -67,9 +67,7 @@ process nMerge {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-{% if nextflow_process_sort_memory %}
-    memory '{{ nextflow_process_sort_memory }}'
-{% endif %}
+    memory '{{ nextflow_process_sort_memory_m }}M'
     publishDir '{{ next_path }}/results/', mode: 'symlink'
     scratch false
     errorStrategy = 'retry'
@@ -83,7 +81,7 @@ process nMerge {
 
     shell:
     '''
-    sort --temporary-directory=. -u !{shard} > !temp.{shard}
+    sort -u -S {{ (nextflow_process_sort_memory_m * 0.8)|int }}M -T . !{shard} > !temp.{shard}
     python -m frag.utils.csv_merge_nodes -i !temp.{shard} -o !{shard}.d-nodes
     '''
 

--- a/ansible/roles/fragment/tasks/main.yaml
+++ b/ansible/roles/fragment/tasks/main.yaml
@@ -23,6 +23,11 @@
     - runpath|string != 'SetMe'
     fail_msg: You must provide a 'deployment', 'vendor', 'version' and default run path where files will be stored.
 
+- name: Assert sort memory
+  assert:
+    that:
+    - nextflow_process_sort_memory_m|int >= 100
+
 # The user is also expected to have defined the environment variables: -
 #
 # - AWS_ACCESS_KEY_ID

--- a/ansible/roles/fragment/templates/fragmentation.nf.j2
+++ b/ansible/roles/fragment/templates/fragmentation.nf.j2
@@ -52,9 +52,7 @@ process collect_nodes {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-{% if nextflow_process_sort_memory %}
-    memory '{{ nextflow_process_sort_memory }}'
-{% endif %}
+    memory '{{ nextflow_process_sort_memory_m }}M'
     publishDir params.out_dir, mode: params.out_mode
     errorStrategy = 'retry'
     maxErrors = 3
@@ -66,7 +64,7 @@ process collect_nodes {
     file 'nodes.csv'
 
     """
-    sort -u -T . $chunks > nodes.csv
+    sort -u -S {{ (nextflow_process_sort_memory_m * 0.8)|int }}M -T . $chunks > nodes.csv
     """
 }
 
@@ -77,9 +75,7 @@ process collect_edges {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-{% if nextflow_process_sort_memory %}
-    memory '{{ nextflow_process_sort_memory }}'
-{% endif %}
+    memory '{{ nextflow_process_sort_memory_m }}M'
     publishDir params.out_dir, mode: params.out_mode
     errorStrategy = 'retry'
     maxErrors = 3
@@ -91,7 +87,7 @@ process collect_edges {
     file 'edges.csv'
 
     """
-    sort -u -T . $chunks > edges.csv
+    sort -u -S {{ (nextflow_process_sort_memory_m * 0.8)|int }}M -T . $chunks > edges.csv
     """
 }
 
@@ -102,9 +98,7 @@ process collect_rejects {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-{% if nextflow_process_sort_memory %}
-    memory '{{ nextflow_process_sort_memory }}'
-{% endif %}
+    memory '{{ nextflow_process_sort_memory_m }}M'
     publishDir params.out_dir, mode: params.out_mode
     errorStrategy = 'retry'
     maxErrors = 3
@@ -116,6 +110,6 @@ process collect_rejects {
     file 'rejects.smi'
 
     """
-    sort -u -T . $chunks > rejects.smi
+    sort -u -S {{ (nextflow_process_sort_memory_m * 0.8)|int }}M -T . $chunks > rejects.smi
     """
 }

--- a/ansible/roles/fragment/templates/fragmentation.nf.j2
+++ b/ansible/roles/fragment/templates/fragmentation.nf.j2
@@ -52,7 +52,7 @@ process collect_nodes {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-    memory '{{ nextflow_process_sort_memory_m }}M'
+    memory '{{ nextflow_process_sort_memory_m }} MB'
     publishDir params.out_dir, mode: params.out_mode
     errorStrategy = 'retry'
     maxErrors = 3
@@ -75,7 +75,7 @@ process collect_edges {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-    memory '{{ nextflow_process_sort_memory_m }}M'
+    memory '{{ nextflow_process_sort_memory_m }} MB'
     publishDir params.out_dir, mode: params.out_mode
     errorStrategy = 'retry'
     maxErrors = 3
@@ -98,7 +98,7 @@ process collect_rejects {
 {% else %}
     container '{{ nextflow_container_name }}:{{ nextflow_container_tag }}'
 {% endif %}
-    memory '{{ nextflow_process_sort_memory_m }}M'
+    memory '{{ nextflow_process_sort_memory_m }} MB'
     publishDir params.out_dir, mode: params.out_mode
     errorStrategy = 'retry'
     maxErrors = 3

--- a/docker-player-entrypoint.sh
+++ b/docker-player-entrypoint.sh
@@ -73,7 +73,11 @@ ansible-playbook "${PLAYBOOK}" -e "@${PARAMETER_FILE}" \
 echo "+> Played"
 
 if [ "${EXIT_CODE}" -ne "0" ]; then
-   echo "+> ERROR - Play ended with exit code ${EXIT_CODE}"
+   echo "   *********"
+   echo "   * ERROR *"
+   echo "   *********"
+   echo "+> Play ended with exit code ${EXIT_CODE}"
+   echo "+> Inspect the Play's output (above) to see what went wrong."
 fi
 
 KEEP_ALIVE_SECONDS=${KEEP_ALIVE_SECONDS:-0}

--- a/docker-player-entrypoint.sh
+++ b/docker-player-entrypoint.sh
@@ -61,14 +61,20 @@ kubectl version
 echo "+> kubectl config set-context..."
 kubectl config set-context --current --namespace="${FRAGMENTOR_NAMESPACE}"
 
-# All set - run the playbook...
+# All set - run the playbook (ignoring but capturing any failure)...
 
 PLAYBOOK="site-${FRAGMENTOR_PLAY}.yaml"
 echo "+> Playing ${PLAYBOOK}..."
 pushd ansible || exit 1
+EXIT_CODE=0
 ansible-playbook "${PLAYBOOK}" -e "@${PARAMETER_FILE}" \
-  -e "ansible_python_interpreter=/usr/local/bin/python"
+  -e "ansible_python_interpreter=/usr/local/bin/python" \
+  || EXIT_CODE=$?
 echo "+> Played"
+
+if [ "${EXIT_CODE}" -ne "0" ]; then
+   echo "+> ERROR - Play ended with exit code ${EXIT_CODE}"
+fi
 
 KEEP_ALIVE_SECONDS=${KEEP_ALIVE_SECONDS:-0}
 echo "+> KEEP_ALIVE_SECONDS is ${KEEP_ALIVE_SECONDS}"


### PR DESCRIPTION
- Misc change to support more control over sort memory (basic tests seem to work on our AWS)
- Payer Entrypoint is now Cmd (allows someone to shell into the player)
- Consistent use of args in sort
- Player now captures ansible exit code printing an ERROR
  This now means plays do not go into a rolling-reboot